### PR TITLE
Implement helper for long messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -170,6 +170,11 @@ ENCODER = tiktoken.encoding_for_model("gpt-4o-mini")
 def count_tokens(text):
     return len(ENCODER.encode(text))
 
+async def send_chunks(message, text, chunk_size=2000):
+    """Send text in chunks not exceeding Discord's 2000 character limit."""
+    for i in range(0, len(text), chunk_size):
+        await message.reply(text[i:i + chunk_size])
+
 
 pending_reset_confirmations = {}
 @client.event
@@ -252,7 +257,7 @@ async def on_message(message):
                 details = getattr(response.usage, "output_tokens_details", {})
                 reasoning_tokens = getattr(details, "reasoning_tokens", 0)
                 visible_tokens = output_tokens - reasoning_tokens
-                await message.reply(reply)
+                await send_chunks(message, reply)
                 count = record_usage("推理")
                 await message.reply(f"📊 今天所有人總共使用「推理」功能 {count} 次，本次使用的模型：{model_used}\n"+"注意沒有網路查詢功能，資料可能有誤\n"
                                     f"📊 token 使用量：\n"
@@ -368,7 +373,7 @@ async def on_message(message):
                 details = getattr(response.usage, "output_tokens_details", {})
                 reasoning_tokens = getattr(details, "reasoning_tokens", 0)
                 visible_tokens = output_tokens - reasoning_tokens
-                await message.reply(reply)
+                await send_chunks(message, reply)
                 await message.reply(f"📊 今天所有人總共使用「問」功能 {count} 次，本次使用的模型：{model_used}\n"+"注意沒有網路查詢功能，資料可能有誤\n"
                                     f"📊 token 使用量：\n"
                                     f"- 輸入 tokens: {input_tokens}\n"
@@ -460,7 +465,7 @@ async def on_message(message):
                 )
 
                     reply_text = "\n".join(part.text for part in response.candidates[0].content.parts if hasattr(part, 'text'))
-                    await message.reply(reply_text)
+                    await send_chunks(message, reply_text)
                     count = record_usage("搜尋")
                     await message.reply(f"📊 今天所有人總共使用「搜尋」功能 {count} 次，本次使用的模型：gemini-2.5-flash-preview-05-20")
 
@@ -495,7 +500,7 @@ async def on_message(message):
                     if response.status_code == 200:
                         data = response.json()
                         reply = data["choices"][0]["message"]["content"]
-                        await message.reply(reply)
+                        await send_chunks(message, reply)
 
                         count = record_usage("搜尋")
                         await message.reply(f"📊 今天所有人總共使用「搜尋」功能 {count} 次，本次使用的模型：{model_used}")


### PR DESCRIPTION
## Summary
- add `send_chunks` helper to avoid 2000-char limit
- use the new helper when replying with potentially long text

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6849551601048332bb8a2e8023dd6f82