### PR TITLE
Simplify Grok tool forcing to direct web_search

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -355,22 +355,11 @@ def create_grok_chat_completion(messages, tools, tool_choice="auto"):
 
 def run_grok_with_tools(messages, max_rounds=3):
     active_tools = build_grok_tools(enable_external_search=True)
-    forced_tool_choices = [
-        {"type": "function", "function": {"name": "web_search"}},
-        {"type": "function", "function": {"name": "x_search"}},
-        "auto",
-    ]
-
-    response = None
-    for forced_choice in forced_tool_choices:
-        response, active_tools = create_grok_chat_completion(messages, active_tools, tool_choice=forced_choice)
-        assistant_message = response.choices[0].message
-        assistant_text = assistant_message.content or ""
-        if assistant_text:
-            messages.append({"role": "assistant", "content": assistant_text})
-
-    if response is None:
-        response, active_tools = create_grok_chat_completion(messages, active_tools)
+    response, active_tools = create_grok_chat_completion(
+        messages,
+        active_tools,
+        tool_choice={"type": "function", "function": {"name": "web_search"}},
+    )
 
     for _ in range(max_rounds):
         assistant_message = response.choices[0].message


### PR DESCRIPTION
### Motivation
- The previous flow attempted multiple forced tool choices (`web_search` → `x_search` → `auto`) and appended intermediate assistant content, which added unnecessary rounds before actual tool execution.
- The change aims to immediately force the initial Grok completion to use the built-in `web_search` function so tool-calling proceeds deterministically and with less overhead.

### Description
- Updated `run_grok_with_tools` in `bot.py` to remove the multi-step `forced_tool_choices` loop and instead call `create_grok_chat_completion` once with `tool_choice={'type': 'function', 'function': {'name': 'web_search'}}`.
- Preserved the existing tool-calling loop (`for _ in range(max_rounds)`) and the logic that collects `tool_calls`, executes tools via `execute_grok_tool`, and appends tool results to `messages`.
- No other behavior or fallback logic in `create_grok_chat_completion` was changed.

### Testing
- Ran `python -m py_compile bot.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699811194d548332a5fdbbcae05b6b41)