### PR TITLE
Avoid local execution of Grok built-in search tools

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -355,22 +355,11 @@ def create_grok_chat_completion(messages, tools, tool_choice="auto"):
 
 def run_grok_with_tools(messages, max_rounds=3):
     active_tools = build_grok_tools(enable_external_search=True)
-    forced_tool_choices = [
-        {"type": "function", "function": {"name": "web_search"}},
-        {"type": "function", "function": {"name": "x_search"}},
-        "auto",
-    ]
-
-    response = None
-    for forced_choice in forced_tool_choices:
-        response, active_tools = create_grok_chat_completion(messages, active_tools, tool_choice=forced_choice)
-        assistant_message = response.choices[0].message
-        assistant_text = assistant_message.content or ""
-        if assistant_text:
-            messages.append({"role": "assistant", "content": assistant_text})
-
-    if response is None:
-        response, active_tools = create_grok_chat_completion(messages, active_tools)
+    response, active_tools = create_grok_chat_completion(
+        messages,
+        active_tools,
+        tool_choice={"type": "function", "function": {"name": "web_search"}},
+    )
 
     for _ in range(max_rounds):
         assistant_message = response.choices[0].message
@@ -378,13 +367,24 @@ def run_grok_with_tools(messages, max_rounds=3):
         if not tool_calls:
             return response, active_tools
 
+        local_tool_calls = []
+        for tool_call in tool_calls:
+            function_data = getattr(tool_call, "function", None)
+            tool_name = getattr(function_data, "name", "")
+            if tool_name == "get_taipei_time":
+                local_tool_calls.append(tool_call)
+
+        # web_search / x_search 等 built-in 工具由模型端處理，不要在本地注入 unknown tool 錯誤。
+        if not local_tool_calls:
+            return response, active_tools
+
         messages.append({
             "role": "assistant",
             "content": assistant_message.content or "",
-            "tool_calls": [build_tool_call_payload(tc) for tc in tool_calls],
+            "tool_calls": [build_tool_call_payload(tc) for tc in local_tool_calls],
         })
 
-        for tool_call in tool_calls:
+        for tool_call in local_tool_calls:
             function_data = getattr(tool_call, "function", None)
             tool_name = getattr(function_data, "name", "")
             tool_args = getattr(function_data, "arguments", "{}")


### PR DESCRIPTION
### Motivation
- The previous flow injected local "unknown tool" results by attempting to execute built-in search tools (`web_search` / `x_search`) with the local `execute_grok_tool`, which broke search-backed answers.
- The initial forced `web_search` request should still be sent to the model/provider side so the provider handles built-in searches deterministically.

### Description
- Keep the first Grok request forced to `web_search` by calling `create_grok_chat_completion(..., tool_choice={"type":"function","function":{"name":"web_search"}})`.
- Add a local filtering step that collects only local/custom tool calls (`get_taipei_time`) and ignores built-in search tool calls so they remain handled by the model/provider.
- When no local tool calls are present, return the Grok response immediately to avoid injecting local `unknown tool` payloads.
- Update the messages and local execution loop to only append and execute `local_tool_calls` instead of all `tool_calls`.

### Testing
- Ran `python -m py_compile bot.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699811194d548332a5fdbbcae05b6b41)