### PR TITLE
Fix 問2 Grok payload to use Responses API model input format

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -363,8 +363,11 @@ def run_grok_with_tools(user_content, max_rounds=3):
     """
     active_tools = build_grok_tools(enable_external_search=True)
 
-    # --- 第一次呼叫：送出使用者訊息 ---
-    input_payload = [{"role": "user", "content": user_content}]
+    # --- 第一次呼叫：帶入系統提示與使用者訊息 ---
+    input_payload = [
+        {"role": "system", "content": ASK_INSTRUCTIONS},
+        {"role": "user", "content": user_content},
+    ]
     response, active_tools = create_grok_response(
         input_payload=input_payload,
         tools=active_tools,
@@ -540,12 +543,13 @@ async def on_message(message):
                 time_now = datetime.now(ZoneInfo("Asia/Taipei"))
                 user_text = build_ask_user_text(prompt, time_now, state.get("summary", ""), False)
 
-                user_content = [{"type": "text", "text": user_text}]
+                user_content = [{"type": "input_text", "text": user_text}]
                 for attachment in message.attachments[:10]:
                     if attachment.content_type and attachment.content_type.startswith("image/"):
                         user_content.append({
-                            "type": "image_url",
-                            "image_url": {"url": attachment.proxy_url}
+                            "type": "input_image",
+                            "image_url": attachment.proxy_url,
+                            "detail": "auto",
                         })
 
                 count = record_usage("問2")


### PR DESCRIPTION
### Motivation
- Ensure Grok (Responses API) receives properly formatted multimodal input to avoid validation errors from legacy chat-completions style payloads. 
- Preserve the assistant/system instructions when starting a Grok interaction so the model receives `ASK_INSTRUCTIONS` alongside user content. 
- Make image and text blocks for `!問2` match the Responses API content block schema for reliable multimodal handling.

### Description
- Prepend a system-role message with `ASK_INSTRUCTIONS` to the initial `input_payload` sent by `run_grok_with_tools` so the model gets the system prompt before user content. 
- Change `!問2` user content blocks from `{"type": "text", ...}` to `{"type": "input_text", ...}`. 
- Change image attachments in `!問2` from the old `{"type": "image_url", "image_url": {"url": ...}}` shape to `{"type": "input_image", "image_url": "<url>", "detail": "auto"}`.

### Testing
- Ran `python -m py_compile bot.py`, which completed successfully. 
- Verified the code parses and constructs the updated `input_payload` and multimodal blocks without syntax errors. 
- No additional automated tests were present or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699821ba3580833289a4afc9fb96320d)