### PR TITLE
Add LINEJS personal account integration mode

### DIFF
--- a/LINE_SETUP.md
+++ b/LINE_SETUP.md
@@ -1,12 +1,22 @@
-# LINE 版本部署說明
+# LINE Bot 版本說明
 
-## 1) 在 LINE Developers 建立 Channel
+此專案目前提供兩種執行模式：
+1. **官方 Messaging API（line-bot-sdk / Channel）**：使用 `line_bot.py`。
+2. **LINEJS 個人帳號模式（linejs）**：使用 `personal_line_bot.js`。
+
+> 注意：LINEJS 屬於非官方個人帳號自動化方式，使用前請先自行確認風險與相關條款。
+
+---
+
+## A) 官方 Messaging API（原本模式）
+
+### 1) 在 LINE Developers 建立 Channel
 1. 到 LINE Developers 建立 **Messaging API channel**。
 2. 取得以下兩個值：
    - `LINE_CHANNEL_ACCESS_TOKEN`（長效 token）
    - `LINE_CHANNEL_SECRET`
 
-## 2) 設定環境變數
+### 2) 設定環境變數
 至少要設定：
 - `LINE_CHANNEL_ACCESS_TOKEN`
 - `LINE_CHANNEL_SECRET`
@@ -19,18 +29,42 @@
 - `OPENAI_ENABLE_WEB_SEARCH`（預設 `true`，啟用自動網路搜尋）
 - `PORT`（預設 `8000`）
 
-## 3) 啟動
+### 3) 啟動
 ```bash
 pip install -r requirements.txt
 python line_bot.py
 ```
 
-## 4) 設定 Webhook URL
+### 4) 設定 Webhook URL
 將 LINE webhook 設為：
 - `https://<你的網域>/webhook/line`
 
-## 5) 使用方式
-使用者在 LINE 傳：
-- `!問 你的問題`
+---
 
-若沒有加 `!問 ` 前綴，機器人會回提示格式。
+## B) LINEJS 個人帳號模式（你要的模式）
+
+### 1) 安裝 Node.js 依賴
+```bash
+npm install
+```
+
+### 2) 設定環境變數
+至少要設定：
+- `OPENAI_API_KEY`
+- `LINE_EMAIL`（LINE 個人帳號登入 email）
+- `LINE_PASSWORD`（LINE 個人帳號登入 password）
+
+可選：
+- `OPENAI_PRIMARY_MODEL`（預設 `gpt-5.5`）
+- `LINEJS_TRIGGER`（預設 `!問`）
+
+### 3) 啟動
+```bash
+npm start
+```
+
+### 4) 使用方式
+在個人帳號收到訊息後：
+- `!問 你的問題`：交給 OpenAI 回答
+- `!功能` 或 `!help`：顯示指令
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dcbot-linejs",
+  "version": "1.0.0",
+  "private": true,
+  "description": "LINEJS personal account bot with OpenAI",
+  "main": "personal_line_bot.js",
+  "scripts": {
+    "start": "node personal_line_bot.js"
+  },
+  "dependencies": {
+    "@evex/linejs": "github:evex-dev/linejs",
+    "openai": "^6.8.1"
+  }
+}

--- a/personal_line_bot.js
+++ b/personal_line_bot.js
@@ -1,0 +1,77 @@
+const OpenAI = require('openai');
+const { Client } = require('@evex/linejs');
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const LINE_EMAIL = process.env.LINE_EMAIL;
+const LINE_PASSWORD = process.env.LINE_PASSWORD;
+const OPENAI_MODEL = process.env.OPENAI_PRIMARY_MODEL || 'gpt-5.5';
+const TRIGGER = process.env.LINEJS_TRIGGER || '!問';
+
+for (const [key, value] of Object.entries({ OPENAI_API_KEY, LINE_EMAIL, LINE_PASSWORD })) {
+  if (!value) {
+    throw new Error(`缺少必要環境變數：${key}`);
+  }
+}
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+const line = new Client({
+  auth: {
+    email: LINE_EMAIL,
+    password: LINE_PASSWORD,
+  },
+});
+
+function shouldReply(text) {
+  if (!text) return false;
+  if (text === '!功能' || text === '!help') return true;
+  return text.startsWith(`${TRIGGER} `);
+}
+
+async function askOpenAI(userText) {
+  const prompt = userText.slice(TRIGGER.length).trim();
+  const resp = await openai.responses.create({
+    model: OPENAI_MODEL,
+    input: [
+      {
+        role: 'system',
+        content: '請以繁體中文回覆，先給結論再簡短補充。',
+      },
+      {
+        role: 'user',
+        content: prompt,
+      },
+    ],
+  });
+
+  return resp.output_text || '目前沒有可回覆的內容。';
+}
+
+async function main() {
+  await line.login();
+  console.log('LINEJS 已登入，開始監聽訊息。');
+
+  line.on('message', async (msg) => {
+    try {
+      const text = (msg?.text || '').trim();
+      if (!shouldReply(text)) return;
+
+      if (text === '!功能' || text === '!help') {
+        await line.replyMessage(msg, [`可用指令：\n1) ${TRIGGER} <問題>\n2) !功能`]);
+        return;
+      }
+
+      const answer = await askOpenAI(text);
+      await line.replyMessage(msg, [answer]);
+    } catch (err) {
+      console.error('訊息處理失敗：', err);
+      try {
+        await line.replyMessage(msg, ['抱歉，剛剛處理失敗，請稍後再試。']);
+      } catch (_) {}
+    }
+  });
+}
+
+main().catch((err) => {
+  console.error('啟動失敗：', err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide an alternative runtime that uses `@evex/linejs` to operate the bot from a personal LINE account instead of the official Messaging API channel.
- Preserve the existing Python `line_bot.py` (Messaging API) flow while offering a trigger-based personal-account mode for simpler personal usage.

### Description
- Added `personal_line_bot.js`, a Node.js entrypoint that logs in with `LINE_EMAIL`/`LINE_PASSWORD`, listens for messages, and forwards `!問 <問題>` prompts to OpenAI Responses API using `OPENAI_API_KEY` while supporting `!功能`/`!help` commands.
- Added `package.json` with dependencies for `@evex/linejs` (pinned to `github:evex-dev/linejs`) and `openai`, and a `npm start` script that runs `personal_line_bot.js`.
- Updated `LINE_SETUP.md` to document dual modes: existing official Messaging API instructions and the new LINEJS personal-account setup (install, required env vars, and start commands).
- No functional changes were made to the existing `line_bot.py` server implementation.

### Testing
- Validated the new script syntax with `node --check personal_line_bot.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a180244b53883329376e71fab6a7731)