### PR TITLE
fix: use npm package name for linejs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node personal_line_bot.js"
   },
   "dependencies": {
-    "@evex/linejs": "npm:@jsr/evex__linejs@^2.8.2",
+    "@evex/linejs": "^2.8.2",
     "openai": "^6.8.1",
     "pg": "^8.16.3"
   }


### PR DESCRIPTION
### Motivation
- Railway deployment failed because `package.json` used a JSR alias (`npm:@jsr/evex__linejs...`) which caused the registry fetch to target `@jsr/evex__linejs` instead of the published `@evex/linejs` package.

### Description
- Update `package.json` to change the `@evex/linejs` dependency from `npm:@jsr/evex__linejs@^2.8.2` to the direct semver `^2.8.2` in `package.json`.

### Testing
- Ran `npm install --omit=dev` in this environment, which still failed with `403 Forbidden` due to registry access policy, but the incorrect `@jsr/...` alias in the manifest has been removed and the dependency declaration is now correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18100b35588332bfff4cb891547e30)