### PR TITLE
Fix Docker/npm setup for JSR LINEJS package (add .npmrc & ESM imports)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@jsr:registry=https://npm.jsr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y git ca-certificates && rm -rf /var/lib/apt/lists/*
 
-COPY package*.json ./
+COPY package*.json .npmrc ./
 RUN npm install --omit=dev
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "start": "node personal_line_bot.js"
   },
   "dependencies": {
-    "@evex/linejs": "^2.8.2",
+    "@evex/linejs": "npm:@jsr/evex__linejs@^3.1.0",
     "openai": "^6.8.1",
     "pg": "^8.16.3"
-  }
+  },
+  "type": "module"
 }

--- a/personal_line_bot.js
+++ b/personal_line_bot.js
@@ -1,6 +1,6 @@
-const OpenAI = require('openai');
-const { Pool } = require('pg');
-const { Client } = require('@evex/linejs');
+import OpenAI from 'openai';
+import { Pool } from 'pg';
+import { Client } from '@evex/linejs';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const LINE_EMAIL = process.env.LINE_EMAIL;


### PR DESCRIPTION
### Motivation
- Ensure the project can install the JSR-provided LINEJS package during local `npm install` and Docker builds by pointing npm at the JSR-compatible registry and using the npm alias format. 
- Make the codebase ESM-compatible because JSR packages are ESM-only and mixing `require` with `import` would crash at runtime.

### Description
- Add a root `.npmrc` with `@jsr:registry=https://npm.jsr.io` to allow resolving JSR compatibility packages via npm. 
- Update `package.json` to set `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18117f069c833289c128b6381a659e)