### PR TITLE
Migrate personal_line_bot.js to latest LINEJS login/listen/reply APIs

### DIFF
--- a/personal_line_bot.js
+++ b/personal_line_bot.js
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
 import { Pool } from 'pg';
-import { Client } from '@evex/linejs';
+import { loginWithPassword } from '@evex/linejs';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const LINE_EMAIL = process.env.LINE_EMAIL;
@@ -29,13 +29,6 @@ const ASK_INSTRUCTIONS = [
 
 const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 const db = new Pool({ connectionString: DATABASE_URL, ssl: { rejectUnauthorized: false } });
-const line = new Client({
-  auth: {
-    email: LINE_EMAIL,
-    password: LINE_PASSWORD,
-  },
-});
-
 async function initDb() {
   await db.query(`
     CREATE TABLE IF NOT EXISTS memory (
@@ -122,8 +115,14 @@ function buildAskUserText(prompt, summary, isFirstTurn) {
 }
 
 function isGroupChat(msg) {
-  const sourceType = msg?.chatType || msg?.toType || msg?.roomType || msg?.sourceType || '';
-  return ['group', 'room'].includes(String(sourceType).toLowerCase());
+  const toType = msg?.to?.type || '';
+  return ['GROUP', 'ROOM'].includes(String(toType).toUpperCase());
+}
+
+async function replyLineMessage(msg, texts) {
+  for (const text of texts) {
+    await msg.reply(String(text));
+  }
 }
 
 function shouldReply(text, groupChat) {
@@ -175,10 +174,25 @@ async function askOpenAI(userText, userId) {
 
 async function main() {
   await initDb();
-  await line.login();
+
+  const line = await loginWithPassword(
+    {
+      email: LINE_EMAIL,
+      password: LINE_PASSWORD,
+      onPincodeRequest(pin) {
+        console.log('LINE 登入 PIN:', pin);
+      },
+    },
+    {
+      device: 'DESKTOPWIN',
+    },
+  );
+
   console.log('LINEJS 已登入，開始監聽訊息。');
 
   line.on('message', async (msg) => {
+    if (msg.isMyMessage) return;
+
     try {
       const text = (msg?.text || '').trim();
       const groupChat = isGroupChat(msg);
@@ -188,12 +202,12 @@ async function main() {
 
       if (text === '!清空記憶') {
         await clearUserMemory(userId);
-        await line.replyMessage(msg, ['已為你完全清空記憶（摘要、對話串接、計數）。']);
+        await replyLineMessage(msg, ['已為你完全清空記憶（摘要、對話串接、計數）。']);
         return;
       }
 
       if (FEATURE_LIST_COMMANDS.has(text)) {
-        await line.replyMessage(msg, [
+        await replyLineMessage(msg, [
           '可用功能：',
           `1) ${TRIGGER} <問題>：向 AI 詢問問題（群組需加關鍵字）`,
           '2) !清空記憶：清除你的對話記憶',
@@ -203,7 +217,7 @@ async function main() {
       }
 
       if (!groupChat && !text.startsWith(`${TRIGGER} `)) {
-        await line.replyMessage(msg, [
+        await replyLineMessage(msg, [
           `請使用：${TRIGGER} <你的問題>`,
           `例如：${TRIGGER} 幫我整理今天 AI 重點新聞`,
           '若要清空記憶：!清空記憶',
@@ -212,14 +226,16 @@ async function main() {
       }
 
       const answers = await askOpenAI(text, userId);
-      await line.replyMessage(msg, answers.slice(0, 5));
+      await replyLineMessage(msg, answers.slice(0, 5));
     } catch (err) {
       console.error('訊息處理失敗：', err);
       try {
-        await line.replyMessage(msg, ['抱歉，剛剛處理失敗，請稍後再試。']);
+        await replyLineMessage(msg, ['抱歉，剛剛處理失敗，請稍後再試。']);
       } catch (_) {}
     }
   });
+
+  line.listen({ talk: true, square: false });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
### Motivation
- 修正因新版 `@evex/linejs` 改動造成的 runtime 錯誤（`line.login is not a function`）並保留原有 bot 邏輯與 LINEJS Talk API 使用方式。 

### Description
- 將 `import { Client } from '@evex/linejs'` 改為 `import { loginWithPassword } from '@evex/linejs'` 並移除舊的 `new Client(...)` 初始化。 
- 在 `main()` 中以 `await loginWithPassword(..., { device: 'DESKTOPWIN' })` 登入，並加入 `onPincodeRequest` PIN 日誌輸出，之後註冊 listener 再呼叫 `line.listen({ talk: true, square: false })`。 
- 新增 `replyLineMessage(msg, texts)` helper，將所有原本的 `line.replyMessage(msg, [...])` 改為透過 `msg.reply(...)` 逐則回覆。 
- 更新 `isGroupChat(msg)` 判斷為 `msg?.to?.type` 結構並新增 `if (msg.isMyMessage) return;` 以避免自回覆迴圈。 

### Testing
- 執行 `npm install --omit=dev`（在此環境嘗試安裝相依時失敗，結果為 npm registry 對 `@jsr/evex__linejs` 回傳 403，安裝失敗）。 (FAILED)
- 使用搜尋檢查舊呼叫 `rg "line\.login\(|line\.replyMessage\(" personal_line_bot.js`，未發現舊 API 呼叫，代表已移除所有 `line.login()` 與 `line.replyMessage()`。 (PASSED)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1812e9352883328068bc19d24e0096)