### PR TITLE
Fix LINE image detection and Blob-to-Base64 conversion

### DIFF
--- a/personal_line_bot.js
+++ b/personal_line_bot.js
@@ -151,29 +151,34 @@ async function safeReadMessage(msg) {
 }
 
 function isAskCommand(text) {
-  return text.startsWith(`${TRIGGER} `);
+  return text === TRIGGER || text.startsWith(`${TRIGGER} `);
 }
 
 function stripTrigger(text) {
   return isAskCommand(text) ? text.slice(TRIGGER.length).trim() : text;
 }
 
+function getMessageContentType(msg) {
+  const talkContentType = msg?.raw?.contentType;
+  if (talkContentType !== undefined && talkContentType !== null) return talkContentType;
+  const squareContentType = msg?.raw?.message?.contentType;
+  if (squareContentType !== undefined && squareContentType !== null) return squareContentType;
+  return msg?.contentType || msg?.type || msg?.messageType || null;
+}
+
 function getChatRoomId(msg) {
   return String(
-    msg?.to?.mid
-    || msg?.to?.id
-    || msg?.chatMid
-    || msg?.chatId
-    || msg?.squareChatMid
-    || msg?.squareChatId
-    || msg?.to?.squareChatMid
+    msg?.raw?.to || msg?.raw?.chatMid || msg?.raw?.message?.to || msg?.to?.mid || msg?.to?.id
+    || msg?.chatMid || msg?.chatId || msg?.squareChatMid || msg?.squareChatId || msg?.to?.squareChatMid
     || 'unknown-room',
   );
 }
 
 function isImageMessage(msg) {
-  const rawType = String(msg?.contentType || msg?.type || msg?.messageType || '').toUpperCase();
-  return rawType.includes('IMAGE') || rawType === '1' || rawType === 'PHOTO';
+  const contentType = getMessageContentType(msg);
+  if (typeof contentType === 'number') return contentType === 1;
+  const normalized = String(contentType || '').trim().toUpperCase();
+  return normalized === '1' || normalized === 'IMAGE';
 }
 
 function cleanupExpiredImages(roomId) {
@@ -195,23 +200,46 @@ function popBufferedImages(roomId) {
   return bucket.slice(-MAX_IMAGES_PER_REQUEST).map((item) => item.dataUrl);
 }
 
+function detectMimeType(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 4) return 'application/octet-stream';
+  if (buffer.length >= 12 && buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46
+    && buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50) return 'image/webp';
+  if (buffer[0] === 0xFF && buffer[1] === 0xD8 && buffer[2] === 0xFF) return 'image/jpeg';
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4E && buffer[3] === 0x47) return 'image/png';
+  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) return 'image/gif';
+  return 'application/octet-stream';
+}
+
+async function blobToBuffer(data) {
+  if (!data) return null;
+  if (Buffer.isBuffer(data)) return data;
+  if (typeof data?.arrayBuffer === 'function') {
+    const arrayBuffer = await data.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  return Buffer.from(data);
+}
+
 async function bufferIncomingImage(msg, roomId) {
   if (typeof msg?.getData !== 'function') return;
-  const imageData = await msg.getData();
-  if (!imageData) return;
-  const byteLength = Buffer.isBuffer(imageData)
-    ? imageData.byteLength
-    : Buffer.byteLength(imageData);
+  const imageBlob = await msg.getData();
+  const buffer = await blobToBuffer(imageBlob);
+  if (!buffer) return;
+  const byteLength = buffer.byteLength;
   if (byteLength > MAX_IMAGE_BYTES) {
     console.warn(`圖片略過：超過大小上限 ${byteLength} bytes > ${MAX_IMAGE_BYTES} bytes`);
     return;
   }
-  const buffer = Buffer.isBuffer(imageData) ? imageData : Buffer.from(imageData);
-  const dataUrl = `data:image/jpeg;base64,${buffer.toString('base64')}`;
+  const mimeType = detectMimeType(buffer);
+  const dataUrl = `data:${mimeType};base64,${buffer.toString('base64')}`;
   cleanupExpiredImages(roomId);
   const existing = roomImageBuffers.get(roomId) || [];
   existing.push({ dataUrl, createdAt: Date.now() });
-  roomImageBuffers.set(roomId, existing.slice(-MAX_IMAGES_PER_REQUEST));
+  const next = existing.slice(-MAX_IMAGES_PER_REQUEST);
+  roomImageBuffers.set(roomId, next);
+  console.log(`[image-buffered] roomId=${roomId} count=${next.length} bytes=${byteLength} mime=${mimeType}`);
 }
 
 async function replyLineMessage(msg, texts) {
@@ -338,6 +366,7 @@ async function main() {
       }
 
       const imageDataUrls = isAskCommand(text) ? popBufferedImages(roomId) : [];
+      console.log(`[ask-openai] roomId=${roomId} images=${imageDataUrls.length} text=${text}`);
       const answers = await askOpenAI(text, userId, imageDataUrls);
       await replyLineMessage(msg, answers.slice(0, 5));
     } catch (err) {


### PR DESCRIPTION
### Motivation
- LINE Talk/Square 訊息的圖片 contentType 位於不同的 `raw` 欄位，且現有判斷未涵蓋，導致圖片無法被辨識與送到 OpenAI。 
- `msg.getData()` 回傳 `Blob` 而非 `Buffer`，直接用 `Buffer.from` 或 `Buffer.byteLength` 會失敗或錯誤計算大小，需先以 `arrayBuffer()` 轉成 `Buffer`。

### Description
- 新增 `getMessageContentType(msg)`，優先讀取 `msg.raw.contentType`（TalkMessage）與 `msg.raw.message.contentType`（SquareMessage），再 fallback 原有欄位。 
- 更新 `isImageMessage(msg)` 支援數字 `1` 與字串 `IMAGE` 的判斷，並使用 `getMessageContentType` 取得類型來源。 
- 改進 `getChatRoomId(msg)` 以先從 `raw` 欄位擷取 room/chat id，提升在不同訊息型別下的一致性。 
- 新增 `blobToBuffer(data)` 與 `detectMimeType(buffer)`，在 `bufferIncomingImage` 中把 `msg.getData()` 的 Blob 以 `await blob.arrayBuffer()` 轉為 `Buffer`，再偵測 MIME 與生成 `data:${mimeType};base64,${base64}` 格式的 data URL，並在暫存成功時 `console.log` 出 `roomId`、`count`、`bytes` 與 `mime`。 
- 在送 OpenAI 前加入 `console.log`，輸出 `roomId`、圖片數量與文字內容。 
- 將 `isAskCommand(text)` 改為支援 `text === TRIGGER` 或 `text.startsWith(`${TRIGGER} `)` 的情況。

### Testing
- 已以 `node --check personal_line_bot.js` 執行語法檢查，結果成功（無語法錯誤）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1827900c5c8332a274146759f39948)